### PR TITLE
Feat/details and fixes

### DIFF
--- a/src/modules/about-us/components/CarouselAdmin/CustomLinks.jsx
+++ b/src/modules/about-us/components/CarouselAdmin/CustomLinks.jsx
@@ -1,55 +1,56 @@
 import {
-	GithubIcon,
-	LinkedinIcon,
-	WebsiteIcon,
-	TwitterIcon,
-	InstagramIcon,
-} from '@icons/Icons';
+  GithubIcon,
+  LinkedinIcon,
+  WebsiteIcon,
+  TwitterIcon,
+  InstagramIcon,
+} from '@icons/Icons'
 
 const ICONS = {
-	github: <GithubIcon />,
-	linkedin: <LinkedinIcon />,
-	website: <WebsiteIcon />,
-	twitter: <TwitterIcon />,
-	instagram: <InstagramIcon />,
-};
+  github: <GithubIcon />,
+  linkedin: <LinkedinIcon />,
+  website: <WebsiteIcon />,
+  twitter: <TwitterIcon />,
+  instagram: <InstagramIcon />,
+}
 
 export const SocialLinks = ({
-	github,
-	linkedin,
-	website,
-	twitter,
-	instagram,
-	className = 'flex gap-3 text-gray-400',
+  github,
+  linkedin,
+  website,
+  twitter,
+  instagram,
+  className = 'flex gap-3 text-gray-400',
 }) => {
-	const links = { github, linkedin, website, twitter, instagram };
+  const links = { github, linkedin, website, twitter, instagram }
 
-	return (
-		<div className={className}>
-			{Object.entries(links).map(([key, url]) => {
-				if (!url) return null;
+  return (
+    <div className={className}>
+      {Object.entries(links).map(([key, url]) => {
+        if (!url) return null
 
-				const label =
-					key === 'github'
-						? 'GitHub profile'
-						: key === 'linkedin'
-						? 'LinkedIn profile'
-						: key === 'website'
-						? 'Personal website'
-						: `${key.charAt(0).toUpperCase() + key.slice(1)} profile`;
+        const label =
+          key === 'github'
+            ? 'GitHub profile'
+            : key === 'linkedin'
+              ? 'LinkedIn profile'
+              : key === 'website'
+                ? 'Personal website'
+                : `${key.charAt(0).toUpperCase() + key.slice(1)} profile`
 
-				return (
-					<a
-						key={key}
-						href={url}
-						target='_blank'
-						rel='noopener noreferrer'
-						className='hover:text-secondary transition-colors'
-						aria-label={label}>
-						{ICONS[key]}
-					</a>
-				);
-			})}
-		</div>
-	);
-};
+        return (
+          <a
+            key={key}
+            href={url}
+            target='_blank'
+            rel='noopener noreferrer'
+            className='hover:text-secondary transition-colors'
+            aria-label={label}
+          >
+            {ICONS[key]}
+          </a>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/modules/about-us/constants/about-us.const.ts
+++ b/src/modules/about-us/constants/about-us.const.ts
@@ -1,5 +1,5 @@
-import { FaDiscord } from "react-icons/fa6";
-import { GoRocket } from "react-icons/go";
+import { FaDiscord } from 'react-icons/fa6'
+import { GoRocket } from 'react-icons/go'
 
 export const socialLinks = {
   discord: {
@@ -14,7 +14,7 @@ export const socialLinks = {
     url: 'https://bento.me/shareit',
     icon: GoRocket,
   },
-};
+}
 
 export const groups = [
   {
@@ -39,21 +39,34 @@ export const groups = [
     title: '🆘  | Mesa de Ayuda',
     description:
       'Lugar para pedir o brindar ayuda rápida sobre temas técnicos o profesionales.',
-    span: "Recuerda: este grupo no reemplaza el canal “#mesa-de - ayuda” de Discord. Si surge una solución útil, te invitamos a publicarla en dicho canal para que quede registrada y pueda ayudar a otros en el futuro. ",
+    span: 'Recuerda: este grupo no reemplaza el canal “#mesa-de - ayuda” de Discord. Si surge una solución útil, te invitamos a publicarla en dicho canal para que quede registrada y pueda ayudar a otros en el futuro. ',
     spanStyle: true,
     size: 'sm:col-span-1 sm:row-span-1',
   },
   {
-    title: "🚀 | Amplify",
+    title: '🚀 | Amplify',
     description: `Amplify es el espacio de la comunidad dedicado a construir y potenciar nuestra presencia profesional en redes. Nace del Content Boost Challenge, donde un grupo de personas se acompañó para desarrollar su marca personal, encontrar su voz y crear contenido con propósito.`,
     span: `En este espacio podés compartir tus publicaciones para recibir feedback, mostrar tu perfil profesional para recibir una revisión, pedir ayuda para planificar contenido y trabajar tu marca personal a tu propio ritmo. También podés aprender de quienes ya vienen creando de forma constante.
 No hay presión por publicar todos los días; solo acompañamiento y guía.`,
     spanStyle: false,
-    size: "sm:col-span-2 sm:row-span-1",
+    size: 'sm:col-span-2 sm:row-span-1',
   },
-];
+]
 
-export const admins = [
+export interface Admin {
+  name: string
+  about: string
+  role: string
+  avatar: string
+  github?: string
+  linkedin: string
+  website?: string
+  twitter?: string
+  instagram?: string
+  description?: string[]
+}
+
+export const admins: Admin[] = [
   {
     name: 'Elias Velázquez (Kani)',
     about: 'Fundador de la Comunidad',
@@ -63,6 +76,14 @@ export const admins = [
     linkedin: 'https://linkedin.com/in/eliassvelazquez',
     website: 'https://linktr.ee/elingenieroconsciente',
     twitter: 'https://x.com/ingeconsciente',
+    description: [
+      'Buenas! Soy Elias (Kani)',
+      'Arranqué en IT en 2024 como Python/ETL Dev y fui evolucionando hacia Data Engineering, trabajando en la construcción de pipelines desde cero. Actualmente estoy profundizando mi formación para crecer en este rol.',
+      'Además de aprender, me gusta enseñar y compartir contenido en redes. También escribo una newsletter (El Ingeniero Consciente) donde mezclo reflexiones personales con recursos sobre Data Engineering y AWS.',
+      'Fuera del mundo tech, existen otras cosas que me encantan, como jugar en la PC, ver series, pelis, leer, caminar, la música (toco teclado y produzco desde 2014) y las buenas conversaciones.',
+      'Dentro de la comunidad, mi foco es impulsar la proactividad y el crecimiento colectivo. A veces puedo ser directo, pero siempre con la intención de que avancemos.',
+      'Si necesitan algo, estoy a un mensaje 👍',
+    ],
   },
   {
     name: 'Natalia Quevedo (Brooke)',
@@ -70,6 +91,10 @@ export const admins = [
     role: 'UX/UI Designer',
     avatar: '/images/naty-avatar.jpg',
     linkedin: 'https://www.linkedin.com/in/natalia-a-quevedo/',
+    description: [
+      'Hola! Soy Brooke. Mi camino en IT no ha sido lineal: pasé por QA, ciberseguridad, y diseño UX UI, hoy me dedico de lleno al soporte técnico LLM. Disfruto resolver problemas y guiar a otros, lo que me llevó a ser admin de este espacio y a trabajar actualmente en Solsteinn, gracias a una gran persona que conocí en esta misma comunidad.',
+      'Cuando apago la pantalla, mi mundo es 100% analógico. Me encontrás entre pinceles, telas y proyectos manuales; creo que esa creatividad artística es el cable a tierra ideal para mi faceta técnica y social. ¡Sigamos creciendo juntos!',
+    ],
   },
   {
     name: 'Jean Roa (Drak)',
@@ -80,6 +105,11 @@ export const admins = [
     linkedin: 'https://www.linkedin.com/in/jeanmra/',
     website: 'https://jeanroa.dev/',
     twitter: 'https://x.com/drakvynhost',
+    description: [
+      'Hallo, soy Jean Roa (Aka Drak), Venezolano en Chile, 29 años. Software Engineer con más de 12 años de experiencia en TI, donde reparé equipos, servidores, deploy, mantenimiento, desarrollo y ahora Hacking y Ciberseguridad.',
+      'He trabajado principalmente como contractor para empresas y equipos de todo el mundo, participando en el desarrollo de aplicaciones web, móviles y de escritorio, además de soluciones de automatización, scripting y mucho más.',
+      'Mi stack principal es Javascript/Typescript, React, React Native, Angular, Python (Flask y Django), SQL, y fanboy de Linux y la estética y2k.',
+      'Me gustan los idiomas, hablo inglés, portugués, español y noruego, me gusta dibujar, el anime, el manga, cocinar, leer, los jueguitos y pasar tiempo con mis hijos y familia.',
+    ],
   },
 ]
-

--- a/src/modules/community/constants/whatsappGroupIcons.ts
+++ b/src/modules/community/constants/whatsappGroupIcons.ts
@@ -1,0 +1,16 @@
+/**
+ * SVG inline para LevelCard (Heroicons-style, MIT).
+ * currentColor + text-white en el círculo del card.
+ */
+const svgAttrs =
+	'xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-7 h-7 text-white" aria-hidden="true"'
+
+export const whatsappGroupIcons = {
+	frontend: `<svg ${svgAttrs}><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75A2.25 2.25 0 0 1 15.75 13.5H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25ZM13.5 6A2.25 2.25 0 0 1 15.75 3.5H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25A2.25 2.25 0 0 1 13.5 8.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25Z" /></svg>`,
+
+	backend: `<svg ${svgAttrs}><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h10.5a2.25 2.25 0 0 0 2.25-2.25V6.75a2.25 2.25 0 0 0-2.25-2.25H6.75A2.25 2.25 0 0 0 4.5 6.75v10.5a2.25 2.25 0 0 0 2.25 2.25Z" /></svg>`,
+
+	data: `<svg ${svgAttrs}><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" /></svg>`,
+
+	security: `<svg ${svgAttrs}><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" /></svg>`,
+} as const

--- a/src/modules/global/components/Header/JoinButton.tsx
+++ b/src/modules/global/components/Header/JoinButton.tsx
@@ -17,7 +17,7 @@ export const JoinButton: React.FC = () => {
 		<>
 			<button
 				onClick={() => setIsFormOpen(true)}
-				className="flex items-center justify-center gap-2 w-full md:w-auto px-4 py-2 rounded-xl bg-orange-500 text-white font-semibold hover:opacity-90 transition-all cursor-pointer"
+				className="flex items-center justify-center gap-2 w-full md:w-auto px-4 py-2 rounded-md bg-orange-500 text-white font-semibold hover:opacity-90 transition-all cursor-pointer"
 			>
 				<span>Únete</span>
 

--- a/src/modules/global/components/Particles/ParticlesHero.astro
+++ b/src/modules/global/components/Particles/ParticlesHero.astro
@@ -1,0 +1,128 @@
+<div id="particles-js" class="absolute inset-0 pointer-events-none select-none"></div>
+
+<script is:inline src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"></script>
+
+<script is:inline>
+  function initParticles() {
+    if (window.particlesJS) {
+      window.particlesJS('particles-js', {
+        particles: {
+          number: {
+            value: 80,
+            density: {
+              enable: true,
+              value_area: 800
+            }
+          },
+          color: {
+            value: "#4b6ef8"
+          },
+          shape: {
+            type: "circle",
+            stroke: {
+              width: 0,
+              color: "#000000"
+            },
+            polygon: {
+              nb_sides: 5
+            }
+          },
+          opacity: {
+            value: 0.5,
+            random: false,
+            anim: {
+              enable: false,
+              speed: 1,
+              opacity_min: 0.1,
+              sync: false
+            }
+          },
+          size: {
+            value: 3,
+            random: true,
+            anim: {
+              enable: false,
+              speed: 40,
+              size_min: 0.1,
+              sync: false
+            }
+          },
+          line_linked: {
+            enable: true,
+            distance: 150,
+            color: "#83D6E7",
+            opacity: 0.4,
+            width: 1
+          },
+          move: {
+            enable: true,
+            speed: 2,
+            direction: "none",
+            random: false,
+            straight: false,
+            out_mode: "out",
+            bounce: false,
+            attract: {
+              enable: false,
+              rotateX: 600,
+              rotateY: 1200
+            }
+          }
+        },
+        interactivity: {
+          detect_on: "canvas",
+          events: {
+            onhover: {
+              enable: true,
+              mode: "grab"
+            },
+            onclick: {
+              enable: true,
+              mode: "push"
+            },
+            resize: true
+          },
+          modes: {
+            grab: {
+              distance: 140,
+              line_linked: {
+                opacity: 1
+              }
+            },
+            bubble: {
+              distance: 400,
+              size: 40,
+              duration: 2,
+              opacity: 8,
+              speed: 3
+            },
+            repulse: {
+              distance: 200,
+              duration: 0.4
+            },
+            push: {
+              particles_nb: 4
+            },
+            remove: {
+              particles_nb: 2
+            }
+          }
+        },
+        retina_detect: true
+      });
+    }
+  }
+
+  // Handle Astro page transitions and initial load
+  document.addEventListener('astro:page-load', initParticles);
+  initParticles();
+</script>
+
+<style>
+  #particles-js {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    z-index: 0;
+  }
+</style>

--- a/src/modules/global/styles/globals.css
+++ b/src/modules/global/styles/globals.css
@@ -84,6 +84,21 @@
 	animation: float 5s ease-in-out infinite;
 }
 
+/**
+ * Subrayado corto bajo la primera palabra (o fragmento) del título.
+ * Uso: <h2>…<span class="section-heading__accent">Amplify</span> – resto</h2>
+ */
+@layer components {
+	.section-heading__accent {
+		@apply inline-block border-b-2 border-secondary pb-0.5;
+	}
+
+	/* Título ya en color secondary: línea contrastada */
+	.section-heading__accent-on-secondary {
+		@apply inline-block border-b-2 border-white pb-0.5;
+	}
+}
+
 /*Card title hover */
 .card-title {
 	transition-property: color, background-color, border-color,

--- a/src/modules/home/components/Amplify/Amplify.astro
+++ b/src/modules/home/components/Amplify/Amplify.astro
@@ -41,7 +41,7 @@ const members = [
 <section class="mb-16">
   <div class="mb-8 text-center px-4">
     <h2 class="text-3xl md:text-4xl font-bold mb-4 text-white">
-      Amplify – Marca Personal
+      <span class="section-heading__accent">Amplify</span> – Marca Personal
     </h2>
     <p class="text-gray-400 max-w-2xl mx-auto text-lg">
       Amplify es el espacio de la comunidad donde construimos y potenciamos nuestra presencia profesional en redes.
@@ -102,18 +102,22 @@ const members = [
   .slider-slide {
     flex: 0 0 100%;
     min-width: 0;
+    min-height: 0;
     margin-bottom: 20px;
-    pointer-events: none; 
+    pointer-events: none;
+    display: flex;
+    flex-direction: column;
+    align-self: stretch;
   }
 
-  
-  .slider-slide :global(a), 
+  .slider-slide :global(a),
   .slider-slide :global(button) {
     pointer-events: auto;
   }
 
- 
   .slider-slide > * {
+    flex: 1 1 auto;
+    min-height: 0;
     width: 100%;
   }
 
@@ -156,133 +160,161 @@ const members = [
 </style>
 
 <script>
-  const track = document.getElementById("sliderTrack") as HTMLElement;
-  const dotsContainer = document.getElementById("sliderDots") as HTMLElement;
-  const dots = dotsContainer.querySelectorAll<HTMLButtonElement>(".dot");
+  type Cleanup = () => void;
 
-  let currentIndex = 0;
-  let isDragging = false;
-  let startX = 0;
-  let currentTranslate = 0;
-  let prevTranslate = 0;
+  let amplifySliderCleanup: Cleanup | undefined;
 
-  const totalSlides = dots.length;
+  function initAmplifySlider() {
+    amplifySliderCleanup?.();
+    amplifySliderCleanup = undefined;
 
-  function getVisibleCount(): number {
-    return window.innerWidth >= 1024 ? 3 : 1;
-  }
+    const track = document.getElementById("sliderTrack") as HTMLElement | null;
+    const dotsContainer = document.getElementById("sliderDots") as HTMLElement | null;
+    if (!track || !dotsContainer) return;
 
-  function maxIndex(): number {
-    return Math.max(0, totalSlides - getVisibleCount());
-  }
+    const dots = dotsContainer.querySelectorAll<HTMLButtonElement>(".dot");
+    const totalSlides = dots.length;
+    if (totalSlides === 0) return;
 
-  function getSlideWidth(): number {
-    const firstSlide = track.children[0] as HTMLElement;
-    return firstSlide ? firstSlide.offsetWidth + 12 : 0; // 12px gap
-  }
+    let currentIndex = 0;
+    let isDragging = false;
+    let startX = 0;
+    let currentTranslate = 0;
+    let prevTranslate = 0;
 
-  function setSliderPosition() {
-    track.style.transform = `translateX(${currentTranslate}px)`;
-  }
+    function getVisibleCount(): number {
+      return window.innerWidth >= 1024 ? 3 : 1;
+    }
 
-  function updateDots() {
-    dots.forEach((dot, i) => {
-      dot.classList.toggle("dot--active", i === currentIndex);
+    function maxIndex(): number {
+      return Math.max(0, totalSlides - getVisibleCount());
+    }
+
+    function getSlideWidth(): number {
+      const firstSlide = track!.children[0] as HTMLElement;
+      return firstSlide ? firstSlide.offsetWidth + 12 : 0;
+    }
+
+    function setSliderPosition() {
+      track!.style.transform = `translateX(${currentTranslate}px)`;
+    }
+
+    function updateDots() {
+      dots.forEach((dot, i) => {
+        dot.classList.toggle("dot--active", i === currentIndex);
+      });
+    }
+
+    function goTo(index: number, animate = true) {
+      currentIndex = Math.min(Math.max(index, 0), maxIndex());
+      currentTranslate = currentIndex * -getSlideWidth();
+      prevTranslate = currentTranslate;
+
+      if (animate) {
+        track!.style.transition = "transform 0.45s cubic-bezier(0.4, 0, 0.2, 1)";
+      } else {
+        track!.style.transition = "none";
+      }
+
+      setSliderPosition();
+      updateDots();
+    }
+
+    function onDragStart(clientX: number) {
+      isDragging = true;
+      startX = clientX;
+      track!.style.transition = "none";
+    }
+
+    function onDragMove(clientX: number) {
+      if (!isDragging) return;
+      const diff = clientX - startX;
+      currentTranslate = prevTranslate + diff;
+
+      const minTranslate = -maxIndex() * getSlideWidth();
+      if (currentTranslate > 0) {
+        currentTranslate = currentTranslate / 3;
+      } else if (currentTranslate < minTranslate) {
+        currentTranslate = minTranslate + (currentTranslate - minTranslate) / 3;
+      }
+
+      setSliderPosition();
+    }
+
+    function onDragEnd() {
+      if (!isDragging) return;
+      isDragging = false;
+
+      const movedBy = currentTranslate - prevTranslate;
+      const threshold = getSlideWidth() / 6;
+
+      if (movedBy < -threshold && currentIndex < maxIndex()) {
+        currentIndex += 1;
+      } else if (movedBy > threshold && currentIndex > 0) {
+        currentIndex -= 1;
+      }
+
+      goTo(currentIndex);
+    }
+
+    const onTrackMouseDown = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.closest("a") || target.closest("button")) return;
+      e.preventDefault();
+      onDragStart(e.clientX);
+    };
+
+    const onWindowMouseMove = (e: MouseEvent) => onDragMove(e.clientX);
+
+    const onTrackTouchStart = (e: Event) => {
+      const te = e as TouchEvent;
+      const target = te.target as HTMLElement;
+      if (target.closest("a") || target.closest("button")) return;
+      onDragStart(te.touches[0].clientX);
+    };
+
+    const onTrackTouchMove = (e: Event) => {
+      if (!isDragging) return;
+      const te = e as TouchEvent;
+      onDragMove(te.touches[0].clientX);
+    };
+
+    const onResize = () => {
+      goTo(Math.min(currentIndex, maxIndex()), false);
+    };
+
+    track.addEventListener("mousedown", onTrackMouseDown);
+    window.addEventListener("mousemove", onWindowMouseMove);
+    window.addEventListener("mouseup", onDragEnd);
+
+    const touchOpts: AddEventListenerOptions = { passive: true };
+    track.addEventListener("touchstart", onTrackTouchStart, touchOpts);
+    track.addEventListener("touchmove", onTrackTouchMove, touchOpts);
+    track.addEventListener("touchend", onDragEnd);
+
+    const dotHandlers: Array<{ el: HTMLButtonElement; fn: () => void }> = [];
+    dots.forEach((dot) => {
+      const fn = () => goTo(Number(dot.dataset.index));
+      dot.addEventListener("click", fn);
+      dotHandlers.push({ el: dot, fn });
     });
+
+    window.addEventListener("resize", onResize);
+
+    goTo(0, false);
+
+    amplifySliderCleanup = () => {
+      track.removeEventListener("mousedown", onTrackMouseDown);
+      window.removeEventListener("mousemove", onWindowMouseMove);
+      window.removeEventListener("mouseup", onDragEnd);
+      track.removeEventListener("touchstart", onTrackTouchStart, touchOpts);
+      track.removeEventListener("touchmove", onTrackTouchMove, touchOpts);
+      track.removeEventListener("touchend", onDragEnd);
+      window.removeEventListener("resize", onResize);
+      dotHandlers.forEach(({ el, fn }) => el.removeEventListener("click", fn));
+    };
   }
 
-  function goTo(index: number, animate = true) {
-    currentIndex = Math.min(Math.max(index, 0), maxIndex());
-    currentTranslate = currentIndex * -getSlideWidth();
-    prevTranslate = currentTranslate;
-    
-    if (animate) {
-      track.style.transition = "transform 0.45s cubic-bezier(0.4, 0, 0.2, 1)";
-    } else {
-      track.style.transition = "none";
-    }
-    
-    setSliderPosition();
-    updateDots();
-  }
-
- 
-
-  function onDragStart(clientX: number) {
-    isDragging = true;
-    startX = clientX;
-    track.style.transition = "none";
-  }
-
-  function onDragMove(clientX: number) {
-    if (!isDragging) return;
-    const currentX = clientX;
-    const diff = currentX - startX;
-    currentTranslate = prevTranslate + diff;
-
-    // Resistencia en bordes
-    const minTranslate = -maxIndex() * getSlideWidth();
-    if (currentTranslate > 0) {
-      currentTranslate = currentTranslate / 3;
-    } else if (currentTranslate < minTranslate) {
-      currentTranslate = minTranslate + (currentTranslate - minTranslate) / 3;
-    }
-
-    setSliderPosition();
-  }
-
-  function onDragEnd() {
-    if (!isDragging) return;
-    isDragging = false;
-    
-    const movedBy = currentTranslate - prevTranslate;
-    const threshold = getSlideWidth() / 6;
-
-    if (movedBy < -threshold && currentIndex < maxIndex()) {
-      currentIndex += 1;
-    } else if (movedBy > threshold && currentIndex > 0) {
-      currentIndex -= 1;
-    }
-
-    goTo(currentIndex);
-  }
-
-  // Mouse Events
-  track.addEventListener("mousedown", (e) => {
-    // Solo si no fue en un link o botón
-    const target = e.target as HTMLElement;
-    if (target.closest('a') || target.closest('button')) return;
-    
-    e.preventDefault();
-    onDragStart(e.clientX);
-  });
-
-  window.addEventListener("mousemove", (e) => onDragMove(e.clientX));
-  window.addEventListener("mouseup", onDragEnd);
-  
-  // Touch Events
-  track.addEventListener("touchstart", (e) => {
-    const target = e.target as HTMLElement;
-    if (target.closest('a') || target.closest('button')) return;
-    onDragStart(e.touches[0].clientX);
-  }, { passive: true });
-
-  track.addEventListener("touchmove", (e) => {
-    if (isDragging) {
-      onDragMove(e.touches[0].clientX);
-    }
-  }, { passive: true });
-
-  track.addEventListener("touchend", onDragEnd);
-
-  // Dots
-  dots.forEach((dot) => {
-    dot.addEventListener("click", () => {
-      goTo(Number(dot.dataset.index));
-    });
-  });
-
-  window.addEventListener("resize", () => {
-    goTo(Math.min(currentIndex, maxIndex()), false);
-  });
+  document.addEventListener("astro:page-load", initAmplifySlider);
+  initAmplifySlider();
 </script>

--- a/src/modules/home/components/Amplify/MemberCard.astro
+++ b/src/modules/home/components/Amplify/MemberCard.astro
@@ -22,21 +22,21 @@ const socials = [
 ].filter(s => s.url);
 ---
 
-<div class="member-card flex flex-col p-6 rounded-2xl bg-[#1d2c49]/40 border border-[#314aa9]/30 transition-all duration-300 backdrop-blur-sm h-full w-full">
+<div class="member-card group flex flex-col flex-1 min-h-0 p-6 rounded-2xl bg-[#1d2c49]/50 border border-[#314aa9]/35 transition-all duration-300 backdrop-blur-sm w-full hover:border-secondary/35 hover:shadow-lg hover:shadow-black/30">
   <!-- Header: avatar + name/role side by side -->
-  <div class="flex items-center gap-4 mb-4">
-    <div class="w-14 h-14 rounded-xl overflow-hidden border-2 border-[#314aa9]/50 avatar-border transition-colors duration-300 flex-shrink-0">
+  <div class="flex items-center gap-4 mb-4 shrink-0">
+    <div class="w-14 h-14 rounded-xl overflow-hidden border-2 border-[#314aa9]/55 avatar-border transition-colors duration-300 flex-shrink-0 group-hover:border-secondary/45">
       <img
         src={photo}
         alt={name}
-        class="w-full h-full object-cover avatar-img transition-transform duration-500"
+        class="w-full h-full object-cover avatar-img transition-transform duration-500 group-hover:scale-[1.03]"
       />
     </div>
-    <div>
-      <h3 class="text-lg font-bold text-white name-text transition-colors duration-300 leading-tight">
+    <div class="min-w-0 text-left">
+      <h3 class="text-lg font-bold text-white name-text transition-colors duration-300 leading-snug">
         {name}
       </h3>
-      <p class="text-gray-400 text-sm font-medium">
+      <p class="text-gray-300/90 text-sm font-medium mt-0.5">
         {role}
       </p>
     </div>
@@ -44,21 +44,21 @@ const socials = [
 
   <!-- Description -->
   {description && (
-    <p class="text-gray-400 text-sm leading-relaxed flex-1 mb-28">
+    <p class="text-gray-300/95 text-sm leading-[1.65] flex-1 min-h-0 [text-wrap:pretty] mb-4">
       {description}
     </p>
   )}
 
   <!-- Social icons -->
   {socials.length > 0 && (
-    <div class="flex items-center gap-3 mt-auto pt-3 border-t border-[#314aa9]/20">
+    <div class="flex items-center gap-3.5 mt-auto pt-4 border-t border-white/[0.08] shrink-0">
       {socials.map(s => (
         <a
           href={s.url}
           target="_blank"
           rel="noopener noreferrer"
           aria-label={s.label}
-          class="social-icon text-gray-400 transition-colors duration-200 text-lg hover:scale-110 transition-transform"
+          class="social-icon text-gray-400/90 transition-all duration-200 text-lg hover:scale-110"
           style={`--hover-color: ${s.color}`}
         >
           <i class={s.icon}></i>

--- a/src/modules/home/components/CommunityValues/CommunityValues.astro
+++ b/src/modules/home/components/CommunityValues/CommunityValues.astro
@@ -37,7 +37,7 @@ const values = [
 <section class="mb-16">
   <div class="mb-8 text-center">
     <h2 class="text-3xl md:text-4xl font-bold mb-4 text-white">
-      Lo que nos hace diferentes
+      <span class="section-heading__accent">Lo</span> que nos hace diferentes
     </h2>
     <p class="text-gray-400 max-w-2xl mx-auto text-lg">
       Nuestra esencia se basa en el apoyo mutuo y el crecimiento compartido.

--- a/src/modules/home/components/ExperienceLevels/ExperienceLevels.astro
+++ b/src/modules/home/components/ExperienceLevels/ExperienceLevels.astro
@@ -26,7 +26,7 @@ const levels = [
 <section class="mb-16">
   <div class="mb-8 text-center">
     <h2 class="text-3xl md:text-4xl font-bold mb-4 text-white">
-      Para Todos los Niveles
+      <span class="section-heading__accent">Para</span> Todos los Niveles
     </h2>
     <p class="text-gray-400 max-w-2xl mx-auto text-lg">
       Nuestra comunidad es inclusiva y abierta a distintos niveles de experiencia. ¡Cualquier persona puede participar!

--- a/src/modules/home/components/ExperienceLevels/LevelCard.astro
+++ b/src/modules/home/components/ExperienceLevels/LevelCard.astro
@@ -4,9 +4,10 @@ interface Props {
   description: string;
   icon: string;
   color: string;
+  tags?: string[];
 }
 
-const { title, description, icon, color } = Astro.props;
+const { title, description, icon, color, tags } = Astro.props;
 ---
 
 <div class={`group p-6 rounded-2xl bg-[#1d2c49]/40 border border-[#314aa9]/30 hover:border-${color} transition-all duration-300 hover:shadow-[0_0_30px_rgba(49,74,169,0.2)] hover:-translate-y-1 flex flex-col items-center text-center backdrop-blur-sm`}>
@@ -19,6 +20,17 @@ const { title, description, icon, color } = Astro.props;
   <p class="text-gray-400 text-sm leading-relaxed">
     {description}
   </p>
+  {
+    tags && tags.length > 0 && (
+      <div class="mt-4 flex flex-wrap gap-2 justify-center">
+        {tags.map((tag) => (
+          <span class="text-xs bg-gray-700/70 text-gray-400 px-2 py-1 rounded-md font-mono">
+            {tag}
+          </span>
+        ))}
+      </div>
+    )
+  }
 </div>
 
 <style>

--- a/src/modules/home/components/SocialLinks/SocialContainer.tsx
+++ b/src/modules/home/components/SocialLinks/SocialContainer.tsx
@@ -53,9 +53,10 @@ export const SocialContainer: React.FC<SocialButtonProps> = ({
   return (
     <div
       className={clsx(
-        'flex items-center text-lg active:scale-95 h-12 justify-center cursor-pointer rounded-md w-full sm:w-auto font-semibold transition-all duration-200 border',
+        'flex items-center text-lg active:scale-95 h-12 justify-center cursor-pointer rounded-md w-full sm:w-auto font-semibold transition-all duration-200 border p-4',
         borderColor,
         textColor
+        
       )}
       style={baseStyle}
       onMouseEnter={() => setIsHovered(true)}

--- a/src/pages/aboutUs.astro
+++ b/src/pages/aboutUs.astro
@@ -1,159 +1,161 @@
 ---
-import { admins } from "src/modules/about-us/constants/about-us.const";
-import Layout from "src/modules/global/layouts/Layout.astro";
-import { SocialLinks } from "src/modules/about-us/components/CarouselAdmin/CustomLinks";
+import { admins } from 'src/modules/about-us/constants/about-us.const'
+import Layout from 'src/modules/global/layouts/Layout.astro'
+import { SocialLinks } from 'src/modules/about-us/components/CarouselAdmin/CustomLinks'
 
-const styledParagraph = "text-[1rem] text-gray-300 leading-relaxed";
-
-const leaderDescriptions = [
-	[
-		"Buenas! Soy Elias (Kani)",
-		"Arranqué en IT en 2024 como Python/ETL Dev y fui evolucionando hacia Data Engineering, trabajando en la construcción de pipelines desde cero. Actualmente estoy profundizando mi formación para crecer en este rol.",
-		"Además de aprender, me gusta enseñar y compartir contenido en redes. También escribo una newsletter (El Ingeniero Consciente) donde mezclo reflexiones personales con recursos sobre Data Engineering y AWS.",
-		"Fuera del mundo tech, existen otras cosas que me encantan, como jugar en la PC, ver series, pelis, leer, caminar, la música (toco teclado y produzco desde 2014) y las buenas conversaciones.",
-		"Dentro de la comunidad, mi foco es impulsar la proactividad y el crecimiento colectivo. A veces puedo ser directo, pero siempre con la intención de que avancemos.",
-		"Si necesitan algo, estoy a un mensaje 👍",
-	],
-	[
-		"Hola! Soy Brooke. Mi camino en IT no ha sido lineal: pasé por QA, ciberseguridad, y diseño UX UI, hoy me dedico de lleno al soporte técnico LLM. Disfruto resolver problemas y guiar a otros, lo que me llevó a ser admin de este espacio y a trabajar actualmente en Solsteinn, gracias a una gran persona que conocí en esta misma comunidad.",
-		"Cuando apago la pantalla, mi mundo es 100% analógico. Me encontrás entre pinceles, telas y proyectos manuales; creo que esa creatividad artística es el cable a tierra ideal para mi faceta técnica y social. ¡Sigamos creciendo juntos!"
-	],
-	[
-		"Hallo, soy Jean Roa (Aka Drak), Venezolano en Chile, 29 años. Software Engineer con más de 12 años de experiencia en TI, donde reparé equipos, servidores, deploy, mantenimiento, desarrollo y ahora Hacking y Ciberseguridad.",
-		"He trabajado principalmente como contractor para empresas y equipos de todo el mundo, participando en el desarrollo de aplicaciones web, móviles y de escritorio, además de soluciones de automatización, scripting y mucho más.",
-		"Mi stack principal es Javascript/Typescript, React, React Native, Angular, Python (Flask y Django), SQL, y fanboy de Linux y la estética y2k.",
-		"Me gustan los idiomas, hablo inglés, portugués, español y noruego, me gusta dibujar, el anime, el manga, cocinar, leer, los jueguitos y pasar tiempo con mis hijos y familia.",
-	],
-];
+const styledParagraph = 'text-[1rem] text-gray-300 leading-relaxed'
+const leaderBioParagraph =
+  'text-[1rem] text-gray-300/95 leading-[1.7] [text-wrap:pretty]'
 ---
 
-<Layout title="Acerca de | Share IT" showBackButton>
-	<div class="max-w-4xl mx-auto cursor-default">
-		<h1 class="text-4xl font-bold text-center mb-8 text-white">
-			Acerca de Nosotros
-		</h1>
-		<p class=`${styledParagraph} mb-2`>
-			Entrar al mundo IT puede sentirse como avanzar sin mapa ni brújula, rodeado de información contradictoria y expectativas que generan más ansiedad que claridad.
-			<b class="text-white">
-				En ShareIT creemos que ese camino no debería recorrerse en soledad.
-			</b>
-			<br /> <br />
-		</p>
+<Layout title='Acerca de | Share IT' showBackButton>
+  <div class='max-w-4xl mx-auto cursor-default'>
+    <h1 class='text-4xl font-bold text-center mb-8 text-white'>
+      Acerca de Nosotros
+    </h1>
+    <p class=`${styledParagraph} mb-2`>
+      Entrar al mundo IT puede sentirse como avanzar sin mapa ni brújula,
+      rodeado de información contradictoria y expectativas que generan más
+      ansiedad que claridad.
+      <b class='text-white'>
+        En ShareIT creemos que ese camino no debería recorrerse en soledad.
+      </b>
+      <br />
+      <br />
+    </p>
 
-		<p>
-			Somos una comunidad que nace con una idea simple: crecer en tecnología es más sostenible cuando se hace en conjunto. Acá no se trata solo de aprender herramientas o conseguir oportunidades, sino de construir un entorno donde las personas realmente se acompañan.
-			<br /> <br />
-		</p>
+    <p>
+      Somos una comunidad que nace con una idea simple: crecer en tecnología es
+      más sostenible cuando se hace en conjunto. Acá no se trata solo de
+      aprender herramientas o conseguir oportunidades, sino de construir un
+      entorno donde las personas realmente se acompañan.
+      <br />
+      <br />
+    </p>
 
+    <p>
+      Nos caracterizamos por algo que no siempre es común en espacios tech: <b
+        class='text-white'>cercanía real</b
+      >. Detrás de cada mensaje hay alguien que escucha, que recuerda, que
+      pregunta cómo fue una entrevista o que se toma el tiempo para ayudar,
+      incluso fuera de horario.
+      <br />
+      <br />
+    </p>
 
-		<p>
-			Nos caracterizamos por algo que no siempre es común en espacios tech: <b class="text-white">cercanía real</b>. Detrás de cada mensaje hay alguien que escucha, que recuerda, que pregunta cómo fue una entrevista o que se toma el tiempo para ayudar, incluso fuera de horario.
-			<br /> <br />
-		</p>
+    <p>
+      Fomentamos un espacio donde:
 
-		<p>
-			Fomentamos un espacio donde:
+      <ul class='list-disc ml-5 mt-6'>
+        <li>Compartimos avances, dudas y frustraciones sin miedo.</li>
+        <li>Celebramos los logros, grandes o pequeños.</li>
+        <li>
+          Nos ayudamos activamente entre quienes están empezando y quienes ya
+          tienen experiencia.
+        </li>
+        <li>
+          Generamos vínculos que trascienden lo digital, también encontrándonos
+          fuera de la pantalla.
+        </li>
+      </ul>
+      <br />
+      <br />
+    </p>
 
-			<ul class="list-disc ml-5 mt-6">
-				<li>Compartimos avances, dudas y frustraciones sin miedo.</li>
-				<li>Celebramos los logros, grandes o pequeños.</li>
-				<li>Nos ayudamos activamente entre quienes están empezando y quienes ya tienen experiencia.</li>
-				<li>Generamos vínculos que trascienden lo digital, también encontrándonos fuera de la pantalla.</li>
-			</ul>
-			<br /> <br />
-		</p>
+    <p class='mb-12'>
+      Además de recursos, oportunidades laborales, talleres y charlas, lo que
+      realmente define a ShareIT es su gente: <b class='text-white'
+        >personas con nombre, historia y ganas de aportar.</b
+      >
+    </p>
 
-		<p class="mb-12">
-			Además de recursos, oportunidades laborales, talleres y charlas, lo que realmente define a ShareIT es su gente: <b class="text-white">personas con nombre, historia y ganas de aportar.</b>
-		</p>
+    <div>
+      <h2 class='text-2xl mt-6 mb-6 font-bold text-white'>
+        <span class='section-heading__accent'>Nuestra</span> cultura
+      </h2>
 
+      <p>En ShareIT valoramos más la actitud que el currículum:</p>
 
+      <ul class='list-disc ml-5 mt-6'>
+        <li>Creemos en la colaboración por encima del ego.</li>
+        <li>
+          Valoramos la presencia y la participación, incluso en lo cotidiano.
+        </li>
+        <li>
+          Fomentamos un ambiente respetuoso, sin competitividad innecesaria.
+        </li>
+        <li>
+          Esperamos que cada persona, en la medida de lo posible, contribuya al
+          crecimiento colectivo.
+        </li>
+      </ul>
+      <br />
+      <br />
+    </div>
 
-		
+    <div class='mb-10'>
+      <p class=''>Este no es un espacio para observar desde afuera.</p>
 
-		<div>
-			<h2 class="text-2xl mt-6 mb-6 font-bold text-white">
-				Nuestra cultura
-			</h2>
+      <p class=''>Es un espacio para construir, compartir y estar presente.</p>
 
-			<p>
-				En ShareIT valoramos más la actitud que el currículum:
-			</p>
+      <p class='font-bold text-white'>Porque nadie despega solo 🚀</p>
+    </div>
 
-			<ul class="list-disc ml-5 mt-6">
-				<li>Creemos en la colaboración por encima del ego.</li>
-				<li>Valoramos la presencia y la participación, incluso en lo cotidiano.</li>
-				<li>Fomentamos un ambiente respetuoso, sin competitividad innecesaria.</li>
-				<li>Esperamos que cada persona, en la medida de lo posible, contribuya al crecimiento colectivo.</li>
-			</ul>
-			<br /> <br />
-		</div>
+    <div class='flex flex-col gap-4 my-3'>
+      <div>
+        <h2 class='text-2xl mt-6 mb-6 font-bold text-white'>
+          <span class='section-heading__accent'>Conoce</span> a los Líderes de
+          Nuestra Comunidad
+        </h2>
 
+        <div class='flex flex-col gap-8'>
+          {
+            admins.map((admin, index) => (
+              <div class='relative overflow-hidden rounded-xl border border-white/[0.08] bg-gray-800/90 p-6 shadow-lg shadow-black/20 md:p-8 flex flex-col md:flex-row gap-8 md:gap-0 md:items-stretch w-full'>
+                <div class='w-full md:w-[280px] text-center shrink-0 md:pr-8'>
+                  <img
+                    src={admin.avatar}
+                    alt={admin.name}
+                    draggable='false'
+                    class='w-32 h-32 rounded-full mb-5 object-cover mx-auto ring-offset-4 ring-offset-gray-800 border-[3px] border-[#83D6E7]'
+                  />
+                  <div class='flex flex-col items-center gap-1'>
+                    <p class='text-lg font-bold text-white tracking-tight'>
+                      {admin.name}
+                    </p>
+                    <span class='text-sm font-semibold text-secondary'>
+                      {admin.role}
+                    </span>
+                    <span class='text-gray-400 text-sm'>{admin.about}</span>
 
-		<div class="mb-10">
-			<p class="">
-				Este no es un espacio para observar desde afuera.
-			</p>
+                    <div class='flex justify-center mt-4 text-xl'>
+                      <SocialLinks
+                        github={admin.github}
+                        linkedin={admin.linkedin}
+                        website={admin.website}
+                        twitter={admin.twitter}
+                        instagram={admin.instagram}
+                        className='flex gap-4 text-secondary/55'
+                      />
+                    </div>
+                  </div>
+                </div>
 
-			<p class="">
-				Es un espacio para construir, compartir y estar presente.
-			</p>
+                <div
+                  class='hidden md:block w-px shrink-0 self-stretch bg-gradient-to-b from-transparent via-gray-600/70 to-transparent my-2'
+                  aria-hidden='true'
+                />
 
-			<p class="font-bold text-white">
-				Porque nadie despega solo 🚀
-			</p>
-		</div>
-
-		
-		
-		
-		<div class="flex flex-col gap-4 my-3">
-			<div>
-				<h2 class="text-2xl mt-6 mb-6 font-bold text-white">
-					Conoce a los Líderes de Nuestra Comunidad
-				</h2>
-
-				<div class="flex flex-col gap-8">
-					{
-						admins.map((admin, index) => (
-							<div class="bg-gray-800 rounded-lg p-6 md:p-8 flex flex-col md:flex-row gap-8 md:items-start w-full">
-								<div class="w-full md:w-[300px] text-center shrink-0">
-									<img
-										src={admin.avatar}
-										alt={admin.name}
-										draggable="false"
-										class="w-32 h-32 rounded-full mb-4 object-cover border-4 border-[#83D6E7] mx-auto"
-									/>
-									<div class="flex flex-col items-center mb-2">
-										<p class="text-lg font-bold text-white">{admin.name}</p>
-										<span class="text-sm font-bold text-secondary">{admin.role}</span>
-										<span class="text-gray-400 text-sm mt-1">{admin.about}</span>
-										
-										<div class="flex justify-center mt-3 text-xl">
-											<SocialLinks
-												github={admin.github}
-												linkedin={admin.linkedin}
-												website={admin.website}
-												twitter={admin.twitter}
-												instagram={admin.instagram}
-												className="flex gap-4 text-gray-400"
-											/>
-										</div>
-									</div>
-								</div>
-
-								<div class="flex-1 space-y-4 border-t border-gray-700 md:border-t-0 md:border-l md:border-gray-700 md:pl-8 pt-6 md:pt-0">
-									{
-										leaderDescriptions[index]?.map((paragraph) => (
-											<p class={styledParagraph}>{paragraph}</p>
-										))
-									}
-								</div>
-							</div>
-						))
-					}
-				</div>
-			</div>
-		</div>
-	</div>
+                <div class='flex-1 min-w-0 max-w-prose space-y-5 border-t border-gray-600/50 pt-6 md:border-t-0 md:pt-0 md:pl-8'>
+                  {admin.description?.map((paragraph) => (
+                    <p class={leaderBioParagraph}>{paragraph}</p>
+                  ))}
+                </div>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </div>
+  </div>
 </Layout>

--- a/src/pages/community.astro
+++ b/src/pages/community.astro
@@ -1,6 +1,40 @@
 ---
 import Layout from "src/modules/global/layouts/Layout.astro";
 import Events from "src/modules/resources/components/Events.astro";
+import LevelCard from "src/modules/home/components/ExperienceLevels/LevelCard.astro";
+import { whatsappGroupIcons } from "src/modules/community/constants/whatsappGroupIcons";
+
+const whatsappGroups = [
+	{
+		title: "Frontend",
+		description:
+			"Este grupo es para quienes están aprendiendo o trabajando en la parte visual de las aplicaciones. Acá hablamos de cómo crear interfaces, mejorar la experiencia del usuario y usar herramientas y frameworks de frontend.",
+		icon: whatsappGroupIcons.frontend,
+		color: "[#60a5fa]",
+	},
+	{
+		title: "Backend",
+		description:
+			"El espacio para entender y construir lo que pasa detrás de una app. Charlamos sobre lógica, APIs, bases de datos y cómo conectar todo para que las cosas funcionen.",
+		icon: whatsappGroupIcons.backend,
+		color: "[#f87171]",
+	},
+	{
+		title: "Data",
+		description:
+			"Este grupo es para quienes están dando sus primeros pasos en datos, cloud, ML e IA. Compartimos recursos, dudas, experiencias y ejemplos reales, con foco en aprender juntos y entender conceptos que a veces parecen más complejos de lo que realmente son.",
+		icon: whatsappGroupIcons.data,
+		color: "[#a78bfa]",
+	},
+	{
+		title: "Ciberseguridad",
+		description:
+			"El espacio para entender cómo se protegen los sistemas y cómo se vulneran. Charlamos sobre ataques, defensas, buenas prácticas y todo lo que hace que las cosas sean (o no sean) seguras.",
+		icon: whatsappGroupIcons.security,
+		color: "[#fbbf24]",
+		tags: ["# recursos", "# libros", "# cursos"],
+	},
+];
 
 /** Vacía el array cuando no haya eventos próximos; el mensaje alternativo se muestra solo en ese caso. */
 const upcomingEvents = [
@@ -35,82 +69,27 @@ const upcomingEvents = [
 	<section class="mb-16" id="canales">
 		<div class="flex items-center gap-3 mt-6 mb-2">
 			<span class="text-2xl">💬</span>
-			<h2 class="text-3xl font-bold text-white">Grupos de whatsapp</h2>
+			<h2 class="text-3xl font-bold text-white">
+				<span class="section-heading__accent">Grupos</span> de whatsapp
+			</h2>
 		</div>
 		<p class="text-gray-400 mb-8 ml-1">
 			Disponemos de distintos grupos para que encuentres siempre
 			el lugar indicado.
 		</p>
 
-		<div class="grid grid-cols-1 sm:grid-cols-2 gap-5">
-			<!-- Card -->
-			<div class="relative block p-6 border rounded-lg border-[#368beb] hover:border-[#83D6E7] bg-gradient-to-br transition-all duration-300 from-[#1a1f2e] via-[#1e2332] to-[#2a2f3e] hover:from-[#1e2332] hover:via-[#2a2f3e] hover:to-[#314aa9]/20">
-				<div class="flex items-center gap-3 mb-3">
-					<div class="w-10 h-10 rounded-xl bg-primary/20 flex items-center justify-center text-xl shrink-0">
-						🎨
-					</div>
-					<h3 class="font-semibold text-white text-lg">Frontend</h3>
-				</div>
-				<p class="text-gray-400 text-sm leading-relaxed">
-					Este grupo es para quienes están aprendiendo o trabajando en la parte visual de las aplicaciones. 
-
-                    Acá hablamos de cómo crear interfaces, mejorar la experiencia del usuario y usar herramientas y frameworks de frontend.
-				</p>
-			</div>
-
-			<div class="relative block p-6 border rounded-lg border-[#368beb] hover:border-[#83D6E7] bg-gradient-to-br transition-all duration-300 from-[#1a1f2e] via-[#1e2332] to-[#2a2f3e] hover:from-[#1e2332] hover:via-[#2a2f3e] hover:to-[#314aa9]/20">
-				<div class="flex items-center gap-3 mb-3">
-					<div class="w-10 h-10 rounded-xl bg-red-500/20 flex items-center justify-center text-xl shrink-0">
-						⚙️
-					</div>
-					<h3 class="font-semibold text-white text-lg">Backend</h3>
-				</div>
-				<p class="text-gray-400 text-sm leading-relaxed">
-					El espacio para entender y construir lo que pasa detrás de una app. 
-
-Charlamos sobre lógica, APIs, bases de datos y cómo conectar todo para que las cosas funcionen.
-				</p>
-				
-			</div>
-
-			<div class="relative block p-6 border rounded-lg border-[#368beb] hover:border-[#83D6E7] bg-gradient-to-br transition-all duration-300 from-[#1a1f2e] via-[#1e2332] to-[#2a2f3e] hover:from-[#1e2332] hover:via-[#2a2f3e] hover:to-[#314aa9]/20">
-				<div class="flex items-center gap-3 mb-3">
-					<div class="w-10 h-10 rounded-xl bg-purple-500/20 flex items-center justify-center text-xl shrink-0">
-						📊
-					</div>
-					<h3 class="font-semibold text-white text-lg">Data</h3>
-				</div>
-				<p class="text-gray-400 text-sm leading-relaxed">
-					Este grupo es para quienes están dando sus primeros pasos en:
-                    Datos, 
-                    Cloud, 
-                    ML,
-                    IA.
-
-                    Compartimos recursos, dudas, experiencias y ejemplos reales, con foco en aprender juntos y entender conceptos que a veces parecen más complejos de lo que realmente son.
-				</p>
-			</div>
-
-			<div class="relative block p-6 border rounded-lg border-[#368beb] hover:border-[#83D6E7] bg-gradient-to-br transition-all duration-300 from-[#1a1f2e] via-[#1e2332] to-[#2a2f3e] hover:from-[#1e2332] hover:via-[#2a2f3e] hover:to-[#314aa9]/20">
-				<div class="flex items-center gap-3 mb-3">
-					<div class="w-10 h-10 rounded-xl bg-yellow-500/20 flex items-center justify-center text-xl shrink-0">
-						🔐
-					</div>
-					<h3 class="font-semibold text-white text-lg">Ciberseguridad</h3>
-				</div>
-				<p class="text-gray-400 text-sm leading-relaxed">
-					El espacio para entender cómo se protegen los sistemas y cómo se vulneran. Charlamos sobre ataques, defensas, buenas prácticas y todo lo que hace que las cosas sean (o no sean) seguras.
-				</p>
-				<div class="mt-4 flex flex-wrap gap-2">
-					<span class="text-xs bg-gray-700/70 text-gray-400 px-2 py-1 rounded-md font-mono"># recursos</span>
-					<span class="text-xs bg-gray-700/70 text-gray-400 px-2 py-1 rounded-md font-mono"># libros</span>
-					<span class="text-xs bg-gray-700/70 text-gray-400 px-2 py-1 rounded-md font-mono"># cursos</span>
-				</div>
-			</div>
-
-			
-
-			
+		<div class="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
+			{
+				whatsappGroups.map((group) => (
+					<LevelCard
+						title={group.title}
+						description={group.description}
+						icon={group.icon}
+						color={group.color}
+						tags={group.tags}
+					/>
+				))
+			}
 		</div>
 
 		
@@ -128,50 +107,52 @@ Charlamos sobre lógica, APIs, bases de datos y cómo conectar todo para que las
 	<section class="mb-16" id="reglas">
 		<div class="flex items-center gap-3 mb-2">
 			<span class="text-2xl">📋</span>
-			<h2 class="text-3xl font-bold text-white">Reglas de convivencia</h2>
+			<h2 class="text-3xl font-bold text-white">
+				<span class="section-heading__accent">Reglas</span> de convivencia
+			</h2>
 		</div>
 		<p class="text-gray-400 mb-8 ml-1">
 			Para mantener un espacio sano, respetuoso y productivo para todos.
 		</p>
 
 		<div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
-			<div class="p-6 flex items-start gap-4 bg-gray-800/40 border border-gray-700/60 rounded-2xl p-5 transition-all duration-200 hover:border-gray-600">
-				<div class="text-2xl font-extrabold text-gray-700 shrink-0 leading-none pt-0.5 select-none">01</div>
+			<div class="group p-6 flex items-start gap-4 bg-gray-800/40 border border-gray-700/60 rounded-2xl p-5 transition-all duration-200 hover:border-gray-600 hover:scale-[1.02]">
+				<div class="text-2xl font-extrabold text-gray-700 group-hover:text-white shrink-0 leading-none pt-0.5 select-none transition-colors duration-200">01</div>
 				<div>
 					<h3 class="font-semibold text-white mb-1">Respeto ante todo</h3>
 					<p class="text-gray-400 text-sm">Tratá a los demás como te gustaría ser tratado/a. No se toleran insultos, discriminación ni actitudes hostiles.</p>
 				</div>
 			</div>
-			<div class="p-6 flex items-start gap-4 bg-gray-800/40 border border-gray-700/60 rounded-2xl p-5 transition-all duration-200 hover:border-gray-600">
-				<div class="text-2xl font-extrabold text-gray-700 shrink-0 leading-none pt-0.5 select-none">02</div>
+			<div class="group p-6 flex items-start gap-4 bg-gray-800/40 border border-gray-700/60 rounded-2xl p-5 transition-all duration-200 hover:border-gray-600 hover:scale-[1.02]">
+				<div class="text-2xl font-extrabold text-gray-700 group-hover:text-white shrink-0 leading-none pt-0.5 select-none transition-colors duration-200">02</div>
 				<div>
 					<h3 class="font-semibold text-white mb-1">Canales correctos</h3>
 					<p class="text-gray-400 text-sm">Publicá en el canal que corresponde al tema. Esto ayuda a mantener las conversaciones ordenadas y fáciles de encontrar.</p>
 				</div>
 			</div>
-			<div class="p-6 flex items-start gap-4 bg-gray-800/40 border border-gray-700/60 rounded-2xl p-5 transition-all duration-200 hover:border-gray-600">
-				<div class="text-2xl font-extrabold text-gray-700 shrink-0 leading-none pt-0.5 select-none">03</div>
+			<div class="group p-6 flex items-start gap-4 bg-gray-800/40 border border-gray-700/60 rounded-2xl p-5 transition-all duration-200 hover:border-gray-600 hover:scale-[1.02]">
+				<div class="text-2xl font-extrabold text-gray-700 group-hover:text-white shrink-0 leading-none pt-0.5 select-none transition-colors duration-200">03</div>
 				<div>
 					<h3 class="font-semibold text-white mb-1">Sin spam ni publicidad</h3>
 					<p class="text-gray-400 text-sm">Está prohibido el spam, la publicidad no solicitada y el envío masivo de mensajes privados a miembros sin su consentimiento.</p>
 				</div>
 			</div>
-			<div class="p-6 flex items-start gap-4 bg-gray-800/40 border border-gray-700/60 rounded-2xl p-5 transition-all duration-200 hover:border-gray-600">
-				<div class="text-2xl font-extrabold text-gray-700 shrink-0 leading-none pt-0.5 select-none">04</div>
+			<div class="group p-6 flex items-start gap-4 bg-gray-800/40 border border-gray-700/60 rounded-2xl p-5 transition-all duration-200 hover:border-gray-600 hover:scale-[1.02]">
+				<div class="text-2xl font-extrabold text-gray-700 group-hover:text-white shrink-0 leading-none pt-0.5 select-none transition-colors duration-200">04</div>
 				<div>
 					<h3 class="font-semibold text-white mb-1">Contenido apropiado</h3>
 					<p class="text-gray-400 text-sm">No compartas contenido ofensivo, violento, pornográfico o ilegal. Mantén el ambiente seguro y adecuado para todos los miembros.</p>
 				</div>
 			</div>
-			<div class="p-6 flex items-start gap-4 bg-gray-800/40 border border-gray-700/60 rounded-2xl p-5 transition-all duration-200 hover:border-gray-600">
-				<div class="text-2xl font-extrabold text-gray-700 shrink-0 leading-none pt-0.5 select-none">05</div>
+			<div class="group p-6 flex items-start gap-4 bg-gray-800/40 border border-gray-700/60 rounded-2xl p-5 transition-all duration-200 hover:border-gray-600 hover:scale-[1.02]">
+				<div class="text-2xl font-extrabold text-gray-700 group-hover:text-white shrink-0 leading-none pt-0.5 select-none transition-colors duration-200">05</div>
 				<div>
 					<h3 class="font-semibold text-white mb-1">Moderación final</h3>
 					<p class="text-gray-400 text-sm">Las decisiones del equipo de moderación son definitivas. Si tenés dudas, podés consultar en privado con los moderadores.</p>
 				</div>
 			</div>
-			<div class="p-6 flex items-start gap-4 bg-gray-800/40 border border-gray-700/60 rounded-2xl p-5 transition-all duration-200 hover:border-gray-600">
-				<div class="text-2xl font-extrabold text-gray-700 shrink-0 leading-none pt-0.5 select-none">06</div>
+			<div class="group p-6 flex items-start gap-4 bg-gray-800/40 border border-gray-700/60 rounded-2xl p-5 transition-all duration-200 hover:border-gray-600 hover:scale-[1.02]">
+				<div class="text-2xl font-extrabold text-gray-700 group-hover:text-white shrink-0 leading-none pt-0.5 select-none transition-colors duration-200">06</div>
 				<div>
 					<h3 class="font-semibold text-white mb-1">Divertirse</h3>
 					<p class="text-gray-400 text-sm">¡Pasala bien! Share IT existe para aprender juntos, hacer networking y crecer. Sé positivo/a y suma a la comunidad.</p>
@@ -201,7 +182,9 @@ Charlamos sobre lógica, APIs, bases de datos y cómo conectar todo para que las
 	<section class="mb-12" id="eventos">
 		<div class="flex items-center gap-3 mb-2">
 			<span class="text-2xl">🗓️</span>
-			<h2 class="text-3xl font-bold text-white">Eventos</h2>
+			<h2 class="text-3xl font-bold text-white">
+				<span class="section-heading__accent">Eventos</span>
+			</h2>
 		</div>
 		<p class="text-gray-400 mb-8 ml-1">
 			Charlas, workshops, espacios de networking y mucho más. ¡No te los pierdas!

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import { AnimatedText } from "src/modules/home/components/AnimatedText/AnimatedText";
 import Layout from "src/modules/global/layouts/Layout.astro";
-import { Image } from "astro:assets";
+import ParticlesHero from "src/modules/global/components/Particles/ParticlesHero.astro";
 import { getCollection } from "astro:content";
 import { getTagNamesByEntries } from "@helpers/tag.helper";
 import { SocialLinks } from "src/modules/home/components/SocialLinks/SocialLinks";
@@ -24,9 +24,9 @@ const tagNamesByResources = await getTagNamesByEntries(latestResources);
 ---
 
 <Layout title="ShareIT - Nadie despega solo" fullWidth={true}>
-	<div class="relative flex items-center justify-center mb-12 min-h-[600px] overflow-hidden">
-		<div class="absolute inset-0 bg-[url('/images/Banner1.jpg')] bg-cover bg-center"></div>
-		<div class="absolute inset-0 bg-black/50"></div>
+	<div class="relative flex items-center justify-center mb-12 min-h-[600px] overflow-hidden bg-[#19243e]">
+		<ParticlesHero />
+		<div class="absolute inset-0 bg-black/35 z-[1] pointer-events-none"></div>
 		<div class="relative text-center px-8 py-12 z-10 font-josefin-sans container mx-auto">
 			<div class="max-w-3xl mx-auto">
 				<AnimatedText client:load />
@@ -61,7 +61,8 @@ const tagNamesByResources = await getTagNamesByEntries(latestResources);
 		<section class="mb-14">
 			<div class="mb-8">
 				<h2 class="text-3xl font-bold mb-4 text-center text-white">
-					🚀 Presentación en Nerdearla 2025
+					🚀 <span class="section-heading__accent">Presentación</span> en
+					Nerdearla 2025
 				</h2>
 				<p class="text-gray-300 text-center m-auto max-w-2xl">
 					Conoce más sobre nuestra visión como comunidad en la siguiente

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -49,7 +49,9 @@ const contentItems = [
 		contentItems.length > 0 ? (
 			<div class='space-y-12'>
 				<section>
-					<h2 class='text-2xl font-bold mb-6 text-secondary'>Artículos</h2>
+					<h2 class='text-2xl font-bold mb-6 text-secondary'>
+						<span class='section-heading__accent-on-secondary'>Artículos</span>
+					</h2>
 					{articles.length > 0 ? (
 						<div class='grid grid-cols-1 md:grid-cols-2 gap-6'>
 							{articles.map((article) => (
@@ -70,7 +72,9 @@ const contentItems = [
 				</section>
 
 				<section>
-					<h2 class='text-2xl font-bold mb-6 text-secondary'>Recursos</h2>
+					<h2 class='text-2xl font-bold mb-6 text-secondary'>
+						<span class='section-heading__accent-on-secondary'>Recursos</span>
+					</h2>
 					{filteredResources.length > 0 ? (
 						<div class='grid grid-cols-1 md:grid-cols-2 gap-6'>
 							{filteredResources.map((resource) => (


### PR DESCRIPTION
## Changes

### Home (`index.astro`)
- Replaced the static banner image with the **`ParticlesHero`** component plus a dark base layer and light overlay for readability.
- Kept existing hero copy and social block.

### Global / typography
- Added **section heading accents** (short cyan underline on the leading word) via `globals.css` (`.section-heading__accent` and variant for secondary-colored titles).
- Applied accents on home sections, community, about us, and tag listing subsections.

### About us
- Refined **leader cards** layout (spacing, avatar ring, divider, bio typography, social links tint).
- Formatting and copy tweaks in `about-us.const` and `aboutUs.astro`; **CustomLinks** formatting cleanup.

### Community
- **WhatsApp groups** now use the same **`LevelCard`** pattern as “Para todos los niveles” on the home page.
- Group icons moved to **inline SVGs** in `src/modules/community/constants/whatsappGroupIcons.ts` (Heroicons-style).
- **Rules** cards: `group` hover — number turns white and slight `scale` on the card.

### Amplify (home)
- **Carousel**: re-initialized on `astro:page-load` with proper **cleanup** of `window` / track listeners so the slider works after View Transitions (navigate away and back).
- **MemberCard**: removed the accidental `mb-28` gap; **flex** layout so testimonial text fills space and **social row** sits at the bottom with equal-height slides on desktop; subtle hover on card, avatar, and borders.

### Misc
- `JoinButton` / `SocialContainer` small adjustments.
- **`ParticlesHero.astro`** available for reuse (particles.js + `astro:page-load`).
